### PR TITLE
Fix: Drush sanitising password

### DIFF
--- a/src/Command/Drupal/DrupalSanitizeDbCommand.php
+++ b/src/Command/Drupal/DrupalSanitizeDbCommand.php
@@ -55,7 +55,8 @@ class DrupalSanitizeDbCommand extends ExtendedCommandBase {
       $dh->execute([
         '-y',
         'sql-sanitize',
-        '--sanitize-email="%name@example.com"'
+        '--sanitize-email="%name@example.com"',
+        '--sanitize-password=password'
       ], $wwwRoot, TRUE);
     }
     catch (\Exception $e) {


### PR DESCRIPTION
if drush is updated past 8.1.13 then password is randomly generated instead of set to 'password'